### PR TITLE
Update Riak config and readme, postgres freebie

### DIFF
--- a/riak/README.md
+++ b/riak/README.md
@@ -8,16 +8,16 @@ Dev tools, which are automatically installed by the vagrant build
 
 https://github.com/basho/riak-client-tools/tree/master/devrel
 
-A development cluster is automativally built for you, with five nodes. To check, test etc, follow the instructions below:
+A development cluster is automatically built for you, with five nodes. To check, test etc, follow the instructions below:
 
-Check installation of cluster
+### Check installation of cluster
 ```
 $ cd Projects/basho/riak/dev
-$ cd ls
+$ ls
 ```
 You should see dev1, dev2 etc
 
-Start
+### Start
 ```
 $ dev1/bin/riak start
 ```
@@ -26,57 +26,58 @@ $ dev1/bin/riak start
 $ for node in dev*; do sudo $node/bin/riak start; done
 ```
 
-Check
+### Check
 ```
 $ ps aux | grep beam
 $ for node in dev*; do sudo $node/bin/riak ping; done
 ```
 
-Create cluster
+### Create cluster
 ```
-$ for n in {2..5}; do sudo dev$n/bin/riak-admin cluster join dev1@127.0.0.1; done
+$ for n in {2..5}; do sudo dev$n/bin/riak-admin cluster join dev1@0.0.0.0; done
 $ sudo dev1/bin/riak-admin cluster plan
 $ sudo dev2/bin/riak-admin cluster commit
 ```
 
-Testing the cluster
+### Testing the cluster
+
+See section below on access from outside the virtual machine for testing using Postman 
 ```
 $ sudo dev1/bin/riak-admin member-status
 $ sudo dev1/bin/riak-admin cluster status
 $ curl -XPUT http://localhost:10018/buckets/welcome/keys/german -H 'Content-Type: text/plain' -d 'herzlich willkommen'
 ```
 
-Your HTTP port might differ, so check your configuration files for the valid port in your cluster. That information can be found in /etc/riak.conf if you're using the newer configuration system or in /etc/app.config if you're using the older system. (Look for listener.http.internal = 127.0.0.1:10018)
+Your HTTP port might differ, so check your configuration files for the valid port in your cluster. That information can be found in /etc/riak.conf if you're using the newer configuration system or in /etc/app.config if you're using the older system. (Look for listener.http.internal = 0.0.0.0:10018)
 ```
 $ curl http://localhost:10018/buckets/welcome/keys/german
 ```
 
 ## Notes when going through book:
  * Remember to run every command with sudo. e.g "dev1/bin/riak start" will not work. "sudo dev1/bin/riak start" will work.
- * dev/dev2/bin/riak-admin join ... has been depricated from this version of riak. Please refer to the notes above on how to create and test a cluster.
- * The book referes to dev/dev1/etc/app.config which is depricated. It is now dev/dev1/etc/riak.conf.
+ * dev/dev2/bin/riak-admin join ... has been deprecated from this version of riak. Please refer to the notes above on how to create and test a cluster.
+ * The book refers to dev/dev1/etc/app.config which is deprecated. It is now dev/dev1/etc/riak.conf.
  * The polly.jpg image has been placed in Projects/basho/riak.
- * The hotel.rb script has been placed in Projects/basho/riak as well. Note the scrip has not been executed.
- * The validators script has been placed in Projects/basho/riak/js_source. Note that the method mentioned in the book regarding including custom js files is depricated. A new file called advanced.config has been created and placed in dev/dev1/etc for the respetive nodes.
+ * The hotel.rb script has been placed in Projects/basho/riak as well. Note the script has not been executed.
+ * The validators script has been placed in Projects/basho/riak/js_source. Note that the method mentioned in the book regarding including custom js files is deprecated. A new file called advanced.config has been created and placed in dev/dev1/etc for the respective nodes.
 
 ## Access outside virtual machine
 
-To access the riak cluster outside of the virtual machine, open the node's config file and replace 
-"listener.http.internal = 127.0.0.1:10018" with 
-"listener.http.internal = 0.0.0.0:10018".
-
-Run the following to restart the nodes.
+Each riak node is configured to run on 0.0.0.0:port, where the port is defined by riak.conf in each dev1...dev5 directory. The sed command below is run by chef to make the nodes accessible from outside the VM, provided the port for the node has been forwarded by the Vagrant config.
 
 ```
-$ for node in dev*; do sudo $node/bin/riak stop; done
-$ for node in dev*; do sudo $node/bin/riak start; done
+cd ~/Projects/basho/riak/dev
+for node in dev*; do sudo sed -i.bak s/127.0.0.1/0.0.0.0/g $node/etc/riak.conf; done
 ```
+When running "vagrant up", pay special attention to the ports that are forwarded from your host system to the virtual machine. If you are having trouble connecting to a particular node, ensure the node is accessible on the correct port inside the VM, and that the VM port is forwarded from the expected port on the host system.
+
+With the cluster accessible from outside the virtual machine, using Postman as an http client makes testing easy. 
+[Install Postman from here](https://www.getpostman.com/) to get started.
 
 From your host machine, do the following to check if it works from any http client: 
 ```
-http://192.168.33.11:10018/ping 
+http://localhost:10018/ping 
 ```
-
 
 For the brave, you can get the server stats by using this:
 ```

--- a/vagrant/cookbooks/postgres/recipes/default.rb
+++ b/vagrant/cookbooks/postgres/recipes/default.rb
@@ -1,5 +1,15 @@
 bash "install_postgres_database" do
   code <<-EOH
-        sudo apt-get -y install postgresql-#{node['postgres']['version']}
+	sudo apt-get -y install postgresql-#{node['postgres']['version']}
   EOH
 end
+
+
+bash "create_vagrant_database" do
+  user "vagrant"
+  environment ({'HOME' => '/home/vagrant', 'USER' => 'vagrant'})
+  code <<-EOH
+  	sudo -u postgres createuser -s $(whoami); createdb $(whoami)
+  EOH
+end
+

--- a/vagrant/cookbooks/riak-dev/recipes/default.rb
+++ b/vagrant/cookbooks/riak-dev/recipes/default.rb
@@ -1,26 +1,29 @@
 bash "install_riak_dev" do
   code <<-EOH
-  		cd /home/vagrant
-		curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
-		chmod a+x kerl
-		sudo apt-get update
-		sudo apt-get -y install build-essential autoconf libncurses5-dev openssl libssl-dev fop xsltproc unixodbc-dev git
-		sudo apt-get -y install libpam0g-dev
-		
-		cd /home/vagrant
-		wget http://s3.amazonaws.com/downloads.basho.com/erlang/otp_src_R16B02-basho8.tar.gz
-		tar zxvf otp_src_R16B02-basho8.tar.gz
-		cd OTP_R16B02_basho8
-		./otp_build autoconf
-		./configure && make && sudo make install
+    cd /home/vagrant
+    curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
+    chmod a+x kerl
+    sudo apt-get update
+    sudo apt-get -y install build-essential autoconf libncurses5-dev openssl libssl-dev fop xsltproc unixodbc-dev git
+    sudo apt-get -y install libpam0g-dev
 
-		cd /home/vagrant
-		mkdir -p Projects/basho
-		cd Projects/basho
-		git clone git://github.com/basho/riak.git
-		cd riak
-		make locked-deps
-		make devrel DEVNODES=5
+    cd /home/vagrant
+    wget http://s3.amazonaws.com/downloads.basho.com/erlang/otp_src_R16B02-basho8.tar.gz
+    tar zxvf otp_src_R16B02-basho8.tar.gz
+    cd OTP_R16B02_basho8
+    ./otp_build autoconf
+    ./configure && make && sudo make install
+
+    cd /home/vagrant
+    mkdir -p Projects/basho
+    cd Projects/basho
+    git clone git://github.com/basho/riak.git
+    cd riak
+    make locked-deps
+    make devrel DEVNODES=5
+
+    cd dev
+    for node in dev*; do sudo sed -i.bak s/127.0.0.1/0.0.0.0/g $node/etc/riak.conf; done
 
     sudo apt-get -y update
     sudo apt-get -y install build-essential zlib1g-dev libssl-dev libreadline6-dev libyaml-dev


### PR DESCRIPTION
Added sed command to replace the ip to 0.0.0.0 automatically for all nodes. No functionality is lost when executing commands from inside the vagrant vm, and people dont need to find and replace 127.0.0.1 manually and restart the nodes in between.

Also added the creation of the vagrant user to save having to change the password for the postgres user to gain access to the database. 

Let me know if I should update the postgres docs to make everyone aware of this change
